### PR TITLE
Arreglado error en cabeceras #71

### DIFF
--- a/ALGI/algi.tex
+++ b/ALGI/algi.tex
@@ -76,7 +76,8 @@
 % CABECERA Y PIE DE PÁGINA
 % ---------------------------------------------------------------------------
 
-\usepackage{fancyhdr}   % Paquete para cabeceras y pies de página
+\usepackage{fancyhdr}	% Paquete para cabeceras y pies de página.
+\usepackage{ragged2e}   % Paquete para manejar las cabeceras multilinea.
 
 % Indica que las páginas usarán la configuración de fancyhdr
 \pagestyle{fancy}
@@ -91,10 +92,10 @@
 \markright{#1}{}}
 
 % Parte derecha de la cabecera
-\fancyhead[LE,RO]{\sffamily\textsl{\rightmark} \hspace{1em}  \textcolor{500}{\rule[-0.4ex]{0.2ex}{1.2em}} \hspace{1em} \thepage}
+\fancyhead[LE,RO]{\sffamily\textsl{\parbox[t]{0.4\textwidth}{\RaggedLeft\rightmark\strut}} \hspace{0.5em} \textcolor{500}{\rule[-0.4ex]{0.2ex}{1.2em}} \hspace{1em} \thepage }
 
 % Parte izquierda de la cabecera
-\fancyhead[RE,LO]{\sffamily{\leftmark}}
+\fancyhead[RE,LO]{\sffamily{\parbox[t]{0.4\textwidth}{\RaggedRight\leftmark\strut}}}
 
 % Elimina la línea de la cabecera
 \renewcommand{\headrulewidth}{0pt}


### PR DESCRIPTION
Usando el paquete ragged2e y editando la plantilla para las cabeceras, se consigue evitar que el texto se solape, separándolo en líneas.