### PR TITLE
VARIOS: arregla los fallos con "*" de #80

### DIFF
--- a/plantilla_md.tex
+++ b/plantilla_md.tex
@@ -54,6 +54,9 @@
 \let\oldsf\sffamily
 \renewcommand*{\sffamily}{\oldsf\sansmath\InSansModetrue}
 
+% Arregla fallos con "*"
+\renewcommand{\textasteriskcentered}{\ensuremath{*}}
+
 % ------------------------------------------------------------------------------
 % DISEÑO DE PÁGINA
 % ------------------------------------------------------------------------------


### PR DESCRIPTION
El carácter del asterisco daba bastantes fallos, se ha podido corregir renombrando el comando en la plantilla_md general.