### PR TITLE
ALGII: Arreglada errata de formato en demostracion de la funcion Phi …

### DIFF
--- a/algii/tema1/tema1.tex
+++ b/algii/tema1/tema1.tex
@@ -62,7 +62,8 @@ Veamos 1. Usamos la propiedad de las unidades del anillo producto que dice que $
 
 Veamos 2. Sea $p \ge 1$ un número primo. 
 \begin{align*}
-    \phi(p^e) &= |\mathcal U(\mathbb{Z}_{p^e})| = |\{r \in \mathcal U(\mathbb{Z}_{p^e}) : r \neq 0, \mcd(r,p^e) = 1\}| \\
+    \phi(p^e) &= |\mathcal U(\mathbb{Z}_{p^e})| \\
+              &= |\{r \in \mathcal U(\mathbb{Z}_{p^e}) : r \neq 0, \mcd(r,p^e) = 1\}| \\
               &= |\mathbb{Z}_{p^e}|-|\{0,p,2p,...,(p-1)p^{e-1}\}| = p^e - p^{e-1} = p^{e-1}(p-1)
 \end{align*}
 \end{proof}

--- a/algii/tema1/tema1.tex
+++ b/algii/tema1/tema1.tex
@@ -60,5 +60,9 @@ La función phi de Euler está dada por: $$\phi(n) := |\mathcal U(\mathbb{Z}_n)|
 \begin{proof}
 Veamos 1. Usamos la propiedad de las unidades del anillo producto que dice que $$\mathcal U(\mathbb{Z}_m \times \mathbb{Z}_n) = \mathcal U(\mathbb{Z}_m) \times \mathcal U(\mathbb{Z}_n)$$ y el teorema chino de los restos que dice que $$\mcd(m,n) = 1 \iff \mathbb{Z}_{mn} \cong \mathbb{Z}_m \times \mathbb{Z}_n$$ De este modo, aplicando la primera propiedad se obtiene que $$|\mathcal U(\mathbb{Z}_m \times \mathbb{Z}_n)| = |\mathcal U(\mathbb{Z}_m)| \times |\mathcal U(\mathbb{Z}_n)| = \phi(m) \phi(n)$$ y aplicando la segunda y el hecho de que los isomorfismos mantienen el número de unidades del anillo tendremos que $$\phi(mn) = |\mathcal U(\mathbb{Z}_{mn})| = |\mathcal U(\mathbb{Z}_m \times \mathbb{Z}_n)|$$
 
-Veamos 2. Sea $p \ge 1$ un número primo. $$\phi(p^e) = |\mathcal U(\mathbb{Z}_{p^e})| = |\{r \in \mathcal U(\mathbb{Z}_{p^e}) : r \neq 0, \mcd(r,p^e) = 1\}| = |\mathbb{Z}_{p^e}|-|\{0,p,2p,...,(p-1)p^{e-1}\}| = p^e - p^{e-1} = p^{e-1}(p-1)$$
+Veamos 2. Sea $p \ge 1$ un número primo. 
+\begin{align*}
+    \phi(p^e) &= |\mathcal U(\mathbb{Z}_{p^e})| = |\{r \in \mathcal U(\mathbb{Z}_{p^e}) : r \neq 0, \mcd(r,p^e) = 1\}| \\
+              &= |\mathbb{Z}_{p^e}|-|\{0,p,2p,...,(p-1)p^{e-1}\}| = p^e - p^{e-1} = p^{e-1}(p-1)
+\end{align*}
 \end{proof}


### PR DESCRIPTION
…de Euler.

Básicamente sustituyo `$$` por un entorno `align*`, cambia un poco el alineado de la ecuación pero mantiene todo lo demás y es legible. Antes el texto sobrepasaba el margen.